### PR TITLE
add trailing / to build dir

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -231,6 +231,9 @@ func (s *Service) Build() error {
 		p = append(p, "..")
 	}
 	outputPath := fmt.Sprintf("%s/%s", strings.Join(p, "/"), s.BuildDir)
+	if !strings.HasSuffix(outputPath, "/") {
+		outputPath += "/"
+	}
 	comArgs := []string{"build", "-o", outputPath}
 	if len(s.LDFlags) > 0 {
 		flags := []string{}


### PR DESCRIPTION
fix service build failing if user has build directory without trailing / in his wingman.yaml

no issues when user has no trailing slash in config
no issues when user has trailing slash in config
no issues when user doesnt have `build_dir` field in config